### PR TITLE
Add missing build dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+criu (3.16.1-2) stable; urgency=medium
+
+  * Add git, libbsd-dev, and libgnutls dependencies
+
+ -- Radostin Stoyanov <radostin@redhat.com>  Fri, 03 Dec 2021 12:18:02 +0000
+
 criu (3.16.1-1) stable; urgency=low
 
   * New upstream version 3.16.1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+criu (3.16.1-3) stable; urgency=medium
+
+  * Explicitly enable FPU on ARM builds to fix FTBFS with gcc-11
+
+ -- Radostin Stoyanov <radostin@redhat.com>  Sun, 05 Dec 2021 09:49:20 +0000
+
 criu (3.16.1-2) stable; urgency=medium
 
   * Add git, libbsd-dev, and libgnutls dependencies

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,11 @@ Build-Depends:
  asciidoctor,
  debhelper (>= 11),
  dh-python,
+ git,
+ libbsd-dev,
  libcap-dev,
+ libgnutls28-dev,
+ libgnutls30,
  libnet1-dev,
  libnl-3-dev,
  libprotobuf-c-dev,
@@ -24,6 +28,7 @@ Rules-Requires-Root: no
 Package: criu
 Architecture: amd64 arm64 armhf ppc64el s390x
 Depends:
+ libgnutls30,
  python3-protobuf,
  ${misc:Depends},
  ${python3:Depends},

--- a/debian/patches/ftbfs-armhf-gcc-11.patch
+++ b/debian/patches/ftbfs-armhf-gcc-11.patch
@@ -1,0 +1,25 @@
+Description: Explicitly enable FPU on ARM builds to fix FTBFS with gcc-11
+ Starting with gcc-11, Debian's armhf compiler no longer builds with
+ a default -mfpu= option. Instead it enables the FPU via an extension
+ to the -march flag (--with-arch=armv7-a+fp). criu's Makefile explicitly
+ passes its own -march=armv7-a setting, which overrides the +fp default,
+ so we end up with no FPU:
+  cc1: error: '-mfloat-abi=hard': selected architecture lacks an FPU
+Origin: vendor
+Bug: https://github.com/checkpoint-restore/criu/issues/1653
+Bug-Debian: https://bugs.debian.org/999680
+Forwarded: no
+Author: Salvatore Bonaccorso <carnil@debian.org>
+Last-Update: 2021-12-04
+
+--- a/Makefile
++++ b/Makefile
+@@ -39,7 +39,7 @@ ifeq ($(ARCH),arm)
+         endif
+ 
+         ifeq ($(ARMV),7)
+-                USERCFLAGS += -march=armv7-a
++                USERCFLAGS += -march=armv7-a+fp
+         endif
+ 
+         ifeq ($(ARMV),8)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+ftbfs-armhf-gcc-11.patch


### PR DESCRIPTION
This pull request adds a few missing build dependencies for the criu package in [OBS](https://build.opensuse.org/package/show/devel:tools:criu/criu).